### PR TITLE
add find package command for required dependency SFML

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ endif()
 include_directories(${CMAKE_SOURCE_DIR}/src/)
 link_directories(${CMAKE_SOURCE_DIR}/src/)
 
+#search for external dependencies
+find_package(SFML REQUIRED)
+
 #put depencencies here
 include_directories(${CMAKE_SOURCE_DIR}/external/include/)
 link_directories(${CMAKE_SOURCE_DIR}/external/lib/)
@@ -36,3 +39,4 @@ endif()
 add_executable(${project_name} main)
 
 target_link_libraries(${project_name} ${${project_name}_external_libs})
+


### PR DESCRIPTION
I wondered that the dependency was not listed with an find_package command. So it runs cmake without an error and compilation crashed due to missing dependency.